### PR TITLE
Add simple IRR calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ The tool operates with Open Street Map and PVGIS APIs for a basic retrieval of c
     3. A tabular display of production across each array per month. The row and column subtotals correspond to per-month and per-array productions respectively.
     4. A total that is the sum of all production.
 
+### Financial Analysis (IRR)
+This tool includes a simple internal rate of return (IRR) calculator. The default cost per kWp is set to **1000 USD**, which reflects the market average for small PV systems according to IRENA's *Renewable Power Generation Costs in 2022*. The default electricity price is **0.15 USD/kWh** and the lifetime is assumed to be 25 years. These values can be adjusted in the app before computing the IRR.
+
 ### Known limitations of the tool. At least some of these can be fixed within the parameters of open-source software and information:
     1. The PVGIS API can show an error 400, which means the coordinates are in the sea. This is a limitation at the level of PVGIS.
     2. Back-to-back modules are manually entered as individual arrays.
@@ -27,7 +30,7 @@ The tool operates with Open Street Map and PVGIS APIs for a basic retrieval of c
     5. The tool does not calculate or account for the type of inverter(s) used in the system.
     6. The accuracy of location identification is dependent on the OpenStreetMap Nominatim API. In some cases, particularly with less specific addresses or newly developed areas, the geocoding might not accurately reflect the actual location.
     7. The tool relies on external APIs for solar irradiation data, which may not fully capture local microclimates or shading from surrounding structures not accounted for in broad datasets.
-    8. The tool does not currently perform detailed financial analyses, such as calculating tax benefits, depreciation, or varying electricity rates over time, which can significantly affect the financial return of solar investments.
+    8. While the tool provides a basic IRR calculator, it does not perform detailed financial analyses such as calculating tax benefits, depreciation, or varying electricity rates over time. These factors can significantly affect the financial return of solar investments.
     9. The tool assumes a fixed orientation and tilt for solar panels. In reality, adjustable mounting systems can optimize panel angles seasonally, potentially enhancing production.
     10. Long-term maintenance, operational costs, and potential system downtime are not considered in the production estimates.
     11. The tool does not take into account local building codes, regulations, or grid connection policies that might impact the feasibility or cost of solar installations.

--- a/financial.py
+++ b/financial.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+DEFAULT_COST_PER_KW = 1000  # USD per kWp (market average, IRENA 2022)
+DEFAULT_ELECTRICITY_PRICE = 0.15  # USD per kWh
+DEFAULT_LIFETIME_YEARS = 25
+
+def estimate_initial_cost(capacity_kw, cost_per_kw=DEFAULT_COST_PER_KW):
+    """Estimate initial investment from capacity in kW and cost per kW."""
+    return capacity_kw * cost_per_kw
+
+
+def estimate_annual_savings(annual_production_kwh, electricity_price=DEFAULT_ELECTRICITY_PRICE):
+    """Estimate annual savings based on production and electricity price."""
+    return annual_production_kwh * electricity_price
+
+
+def calculate_irr(initial_cost, annual_savings, lifetime_years=DEFAULT_LIFETIME_YEARS):
+    """Calculate internal rate of return for a PV system."""
+    cash_flows = [-initial_cost] + [annual_savings] * lifetime_years
+    irr = np.irr(cash_flows)
+    return irr


### PR DESCRIPTION
## Summary
- create a `financial` helper with IRR calculation and market-average defaults
- support returning total PV capacity from production calculation
- show an IRR calculation in Streamlit under a new *Financial Analysis* expander
- document the new feature in the README with references to market averages

## Testing
- `python -m py_compile streamlit_app.py financial.py`

------
https://chatgpt.com/codex/tasks/task_e_688b365459e48324b2500cf8701e3083